### PR TITLE
🔧 Hotfix: Mobile header layout improvements

### DIFF
--- a/components/AppHeader/AppHeader.vue
+++ b/components/AppHeader/AppHeader.vue
@@ -1,15 +1,15 @@
 <template>
-  <header class="relative flex items-center px-6 py-3 bg-white/80 dark:bg-sakai-surface-800/80 backdrop-blur-sm border-b border-sakai-surface-200 dark:border-sakai-surface-600">
+  <header class="relative flex items-center px-3 xs:px-6 py-3 bg-white/80 dark:bg-sakai-surface-800/80 backdrop-blur-sm border-b border-sakai-surface-200 dark:border-sakai-surface-600">
     <!-- Logo -->
     <div class="flex items-center space-x-2">
       <div class="w-8 h-8 bg-sakai-primary rounded-lg flex items-center justify-center">
         <Icon name="bxs:chart" class="w-5 h-5 text-white" />
       </div>
-      <span class="text-xl font-semibold text-sakai-text-primary dark:text-white">{{ $t('header.title') }}</span>
+      <span class="text-lg xs:text-xl font-semibold text-sakai-text-primary dark:text-white">{{ $t('header.title') }}</span>
     </div>
     
-    <!-- Navigation Tabs - Centered -->
-    <nav class="absolute left-1/2 transform -translate-x-1/2 flex items-center space-x-1">
+    <!-- Navigation Tabs - Responsive positioning -->
+    <nav class="absolute right-16 xs:left-1/2 xs:right-auto xs:transform xs:-translate-x-1/2 flex items-center space-x-1">
       <NuxtLink
         to="/"
         @click="trackNavigation('calculator')"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,9 @@ export default {
   ],
   theme: {
     extend: {
+      screens: {
+        'xs': '500px',
+      },
       colors: {
         'sakai': {
           primary: '#10b981',


### PR DESCRIPTION
## 🚨 Hotfix: Mobile Header Layout Issues

This hotfix resolves critical layout issues on mobile devices where the navigation was overlapping with the logo on screens below 500px width.

## 🔧 Changes Made

### **Responsive Breakpoint System**
- ✅ **Added custom `xs` breakpoint** at 500px in `tailwind.config.js`
- ✅ **Enables precise control** for very small screen layouts

### **Mobile Header Optimizations**
- ✅ **Reduced font size**: "Deck Optimize" title uses `text-lg` on mobile (was `text-xl`)
- ✅ **Decreased padding**: Header padding reduced to `px-3` on mobile (was `px-6`)
- ✅ **Fixed navigation positioning**: Right-aligned on screens <500px, centered on ≥500px

## 🎯 Problem Solved

**Before**: Navigation tabs were overlapping with the logo on very small screens
**After**: Navigation properly positioned to the right on mobile, centered on larger screens

## 📱 Responsive Behavior

| Screen Size | Logo Font | Header Padding | Navigation Position |
|-------------|-----------|----------------|---------------------|
| < 500px     | `text-lg` | `px-3`         | Right-aligned       |
| ≥ 500px     | `text-xl` | `px-6`         | Centered            |

## 🧪 Testing

- [x] Builds successfully without errors
- [x] Navigation no longer overlaps logo on mobile
- [x] Maintains existing behavior on desktop
- [x] Preserves all existing functionality

## 📋 Files Changed

- `components/AppHeader/AppHeader.vue`: Responsive classes for font size, padding, and navigation positioning
- `tailwind.config.js`: Added custom `xs` breakpoint for 500px threshold

## ⚡ Impact

- **Critical**: Fixes broken mobile navigation layout
- **Zero breaking changes**: All existing functionality preserved
- **Improved UX**: Better mobile usability and visual hierarchy

🤖 Generated with [Claude Code](https://claude.ai/code)